### PR TITLE
chore: pin `flict==2.1.14`

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -163,7 +163,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: install flict
-        run: pip install flict
+        run: pip install flict==1.2.14
       - name: Checkout
         # see https://github.com/actions/checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
fixes #194