### PR TITLE
Switch to a TypeScript version that is compatible with the used ESLint version.

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_ACTIVE_LTS: '20'  # https://nodejs.org/en/about/releases/
+  NODE_ACTIVE_LTS: '22'  # https://nodejs.org/en/about/releases/
   BUNDLES_DIR: bundles
   DIST_DIR: dist
   REPORTS_DIR: "CI_reports"
@@ -209,8 +209,8 @@ jobs:
         node-version:
           ## action based on https://github.com/actions/node-versions/releases
           ## see also: https://nodejs.org/en/about/releases/
-          - '22'      # Current
-          - '20'      # LTS
+          - '22'      # Current LTS
+          - '20'      # last LTS
           - '18'      # lowest supported
         os:
           - 'ubuntu-latest'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_ACTIVE_LTS: '22'  # https://nodejs.org/en/about/releases/
+  NODE_ACTIVE_LTS: '20'  # https://nodejs.org/en/about/releases/
   BUNDLES_DIR: bundles
   DIST_DIR: dist
   REPORTS_DIR: "CI_reports"
@@ -209,8 +209,8 @@ jobs:
         node-version:
           ## action based on https://github.com/actions/node-versions/releases
           ## see also: https://nodejs.org/en/about/releases/
-          - '22'      # Current LTS
-          - '20'      # last LTS
+          - '22'      # LTS
+          - '20'
           - '18'      # lowest supported
         os:
           - 'ubuntu-latest'

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "mocha": "10.7.3",
     "npm-run-all2": "^6.1.2",
     "rimraf": "^5.0.5",
-    "typescript": "5.6.2"
+    "typescript": "<5.4.0"
   },
   "type": "commonjs",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@types/hosted-git-info": "^3.0.5",
     "@types/mocha": "^10.0.6",
-    "@types/node": "18.11.9",
+    "@types/node": "ts5.3",
     "@types/normalize-package-data": "^2.4.4",
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@types/hosted-git-info": "^3.0.5",
     "@types/mocha": "^10.0.6",
-    "@types/node": "ts5.6",
+    "@types/node": "18.11.9",
     "@types/normalize-package-data": "^2.4.4",
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",
@@ -89,7 +89,7 @@
     "mocha": "10.7.3",
     "npm-run-all2": "^6.1.2",
     "rimraf": "^5.0.5",
-    "typescript": "<5.4.0"
+    "typescript": "5.3.3"
   },
   "type": "commonjs",
   "engines": {


### PR DESCRIPTION
I could not run `yarn run test:lint` as the TypeScript version 5.6.2 seem to be incompatible with the ESLint version 8.57 or some of the used ESLint plugins.

It says complains about not finding some dependencies (log shortended here)
```
src/plugin.ts:21:29 - error TS2307: Cannot find module '@yarnpkg/core' or its corresponding type declarations.

21 import type { Plugin } from '@yarnpkg/core'
                               ~~~~~~~~~~~~~~~

src/plugin.ts:27:28 - error TS4113: This member cannot have an 'override' modifier because it is not declared in the base class 'MakeSbomCommand'.

27   static override readonly paths = [
                              ~~~~~

src/plugin.ts:35:28 - error TS4112: This member cannot have an 'override' modifier because its containing class 'CyclonedxVersionCommand' does not extend another class.

35   static override readonly paths = CyclonedxCommand.paths.map(p => [...p, '--version'])
                              ~~~~~

src/plugin.ts:39:10 - error TS2339: Property 'context' does not exist on type 'CyclonedxVersionCommand'.

39     this.context.stdout.write(`${name} v${version}\n`)
            ~~~~~~~


Found 38 errors in 6 files.

Errors  Files
     3  src/_helpers.ts:20
     1  src/_yarnCompat.ts:20
    10  src/builders.ts:21
    17  src/commands.ts:21
     2  src/logger.ts:20
     5  src/plugin.ts:20
```

Once the TypeScript version is switched, ESLint runs without errors.