### PR TITLE
Change exit code to 1 whenever an error was logged.

### DIFF
--- a/src/builders.ts
+++ b/src/builders.ts
@@ -37,6 +37,7 @@ import {
   trySanitizeGitUrl
 } from './_helpers'
 import { wsAnchoredPackage } from './_yarnCompat'
+import { type Logger as ConsoleLoggger } from './logger'
 import { PropertyNames, PropertyValueBool } from './properties'
 
 type ManifestFetcher = (pkg: Package) => Promise<any>
@@ -61,7 +62,7 @@ export class BomBuilder {
   shortPURLs: boolean
   gatherLicenseTexts: boolean
 
-  console: Console
+  console: ConsoleLoggger
 
   constructor (
     toolBuilder: BomBuilder['toolBuilder'],
@@ -134,7 +135,7 @@ export class BomBuilder {
     )) {
       component.licenses.forEach(setLicensesDeclared)
 
-      this.console.info('INFO  | add component for %s/%s@%s',
+      this.console.info('add component for %s/%s@%s',
         component.group ?? '-',
         component.name,
         component.version ?? '-'
@@ -259,7 +260,7 @@ export class BomBuilder {
     const component = this.componentBuilder.makeComponent(
       manifestC as normalizePackageData.Package, type)
     if (component === undefined) {
-      this.console.debug('DEBUG | skip broken component: %j', locator)
+      this.console.debug('skip broken component: %j', locator)
       return undefined
     }
 
@@ -382,15 +383,15 @@ export class BomBuilder {
             fetchManifest, fetchLicenseEvidences)
           if (_depC === false) {
             // shall be skipped
-            this.console.debug('DEBUG | skip impossible component %j', _depIDN)
+            this.console.debug('skip impossible component %j', _depIDN)
             continue // for-loop
           }
           if (_depC === undefined) {
             depComponent = new DummyComponent(ComponentType.Library, `InterferedDependency.${_depIDN}`)
-            this.console.warn('WARN  | InterferedDependency %j', _depIDN)
+            this.console.warn('InterferedDependency %j', _depIDN)
           } else {
             depComponent = _depC
-            this.console.debug('DEBUG | built component %j: %j', _depIDN, depComponent)
+            this.console.debug('built component %j: %j', _depIDN, depComponent)
           }
           yield depComponent
           knownComponents.set(depPkg.locatorHash, depComponent)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -138,8 +138,8 @@ export class MakeSbomCommand extends Command<CommandContext> {
     const projectDir = this.context.cwd
 
     const myConsole = makeConsoleLogger(this.verbosity, this.context)
-    myConsole.debug('DEBUG | YARN_VERSION:', YarnVersionTuple)
-    myConsole.debug('DEBUG | options: %j', {
+    myConsole.debug('YARN_VERSION:', YarnVersionTuple)
+    myConsole.debug('options: %j', {
       specVersion: this.specVersion,
       outputFormat: this.outputFormat,
       outputFile: this.outputFile,
@@ -152,20 +152,20 @@ export class MakeSbomCommand extends Command<CommandContext> {
       projectDir
     })
 
-    myConsole.info('INFO  | gathering project & workspace ...')
+    myConsole.info('gathering project & workspace ...')
     const { project, workspace } = await Project.find(
       await Configuration.find(projectDir, this.context.plugins),
       projectDir)
     if (workspace === null) {
       throw new Error(`missing workspace for project ${project.cwd} in ${projectDir}`)
     }
-    myConsole.debug('DEBUG | project:', project.cwd)
-    myConsole.debug('DEBUG | workspace:', workspace.cwd)
+    myConsole.debug('project:', project.cwd)
+    myConsole.debug('workspace:', workspace.cwd)
     await workspace.project.restoreInstallState()
 
     const extRefFactory = new PJF.ExternalReferenceFactory()
 
-    myConsole.log('LOG   | gathering BOM data ...')
+    myConsole.log('gathering BOM data ...')
     const bom = await (new BomBuilder(
       new PJB.ToolBuilder(extRefFactory),
       new PJB.ComponentBuilder(
@@ -198,7 +198,7 @@ export class MakeSbomCommand extends Command<CommandContext> {
         break
     }
 
-    myConsole.log('LOG   | serializing BOM ...')
+    myConsole.log('serializing BOM ...')
     const serialized = serializer.serialize(bom, {
       sortLists: this.outputReproducible,
       space: 2
@@ -206,16 +206,16 @@ export class MakeSbomCommand extends Command<CommandContext> {
 
     // @TODO validate BOM - see https://github.com/CycloneDX/cyclonedx-node-yarn/issues/23
 
-    myConsole.log('LOG   | writing BOM to: %s', this.outputFile)
+    myConsole.log('writing BOM to: %s', this.outputFile)
     const written = await writeAllSync(
       this.outputFile === OutputStdOut
         ? process.stdout.fd
         : xfs.openSync(npath.toPortablePath(npath.resolve(process.cwd(), this.outputFile)), 'w'),
       serialized
     )
-    myConsole.info('INFO  | wrote %d bytes to: %s', written, this.outputFile)
+    myConsole.info('wrote %d bytes to: %s', written, this.outputFile)
 
-    return written > 0
+    return !myConsole.didLogError && written > 0
       ? ExitCode.SUCCESS
       : ExitCode.FAILURE
   }


### PR DESCRIPTION
This is a preparation for #228 

Adds a wrapper around the native console API to track if any errors were logged. If this is the case a non-zero exit code is set (via Clipanion as it sets exit codes after plugin commands are complete in https://github.com/arcanis/clipanion/blob/master/sources/advanced/Cli.ts#L551).

This PR does not include adding additional logs to address #228 