### PR TITLE
chore: QA tool to detect missing dependencies

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -133,6 +133,30 @@ jobs:
       - name: test
         run: yarn run test:lint
 
+  test-dependencies:
+    name: test lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@v4
+      - run: mkdir -p ${{ env.REPORTS_DIR }}
+      - name: Setup Node.js ${{ matrix.node-version }}
+        # see https://github.com/actions/setup-node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_ACTIVE_LTS }}
+          # cache: 'yarn'
+      - name: Setup yarn
+        run: corepack enable yarn
+      - name: Setup subject
+        run: yarn install --immutable
+      - name: build
+        run: yarn run build:gbti
+      - name: test
+        run: yarn run test:dependencies
+
   test-licenses:
     needs: [ 'build' ]
     name: test licenses

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://unpkg.com/knip@5/schema-jsonc.json",
+  "entry": [
+    "src/plugin.ts!",
+    "bin/**!",
+    "index.js!"
+  ],
+  "project": [
+    "src/**!",
+    "bin/**!",
+    "tests/**"
+  ],
+  "ignore": [
+    "tests/_data/testbeds/**"
+  ],
+  "ignoreDependencies": [
+    "xmlbuilder2" // << needed to force the installation of an optional dependency ofa 3rd party package
+  ]
+}

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -15,7 +15,7 @@
     "tools/**"
   ],
   "ignoreDependencies": [
+    // needed to force the installation of the optional dependency of a 3rd party package:
     "xmlbuilder2"
-    // << needed to force the installation of an optional dependency ofa 3rd party package
   ]
 }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -8,12 +8,14 @@
   "project": [
     "src/**!",
     "bin/**!",
-    "tests/**"
+    "tests/**",
+    "!tests/_data/testbeds/**"
   ],
   "ignore": [
-    "tests/_data/testbeds/**"
+    "tools/**"
   ],
   "ignoreDependencies": [
-    "xmlbuilder2" // << needed to force the installation of an optional dependency ofa 3rd party package
+    "xmlbuilder2"
+    // << needed to force the installation of an optional dependency ofa 3rd party package
   ]
 }

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "test:standard": "eslint .",
     "test:lint": "tsc --noEmit",
     "test:node": "c8 mocha -p",
-    "test:dependencies": "knip --include dependencies --production",
+    "test:dependencies": "knip --include dependencies,unlisted,unresolved --production",
     "cs-fix": "eslint --fix .",
     "dogfooding": "node $PROJECT_CWD/bin/cyclonedx-yarn-cli.js"
   },

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "extract-zip": "^2.0.1",
     "fast-glob": "^3.3.2",
     "globals": "^16.0.0",
+    "knip": "5.61.3",
     "mkdirp": "^3.0.1",
     "mocha": "11.7.1",
     "neostandard": "0.12.2",
@@ -147,6 +148,7 @@
     "test:standard": "eslint .",
     "test:lint": "tsc --noEmit",
     "test:node": "c8 mocha -p",
+    "test:dependencies": "knip --include dependencies --production",
     "cs-fix": "eslint --fix .",
     "dogfooding": "node $PROJECT_CWD/bin/cyclonedx-yarn-cli.js"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -229,6 +229,7 @@ __metadata:
     fast-glob: "npm:^3.3.2"
     globals: "npm:^16.0.0"
     hosted-git-info: "npm:8.1.0"
+    knip: "npm:5.61.3"
     mkdirp: "npm:^3.0.1"
     mocha: "npm:11.7.1"
     neostandard: "npm:0.12.2"
@@ -606,6 +607,141 @@ __metadata:
   version: 8.3.8
   resolution: "@oozcitak/util@npm:8.3.8"
   checksum: 10c0/1c492abcba79f5dd9bd7709331a614114706e6936a899cac6ac90b63bbe8e98da288e664c13c6acb2a38e3c5ffd47b93f824075ba81384d6192cc364bf126775
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-android-arm-eabi@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-android-arm-eabi@npm:11.5.2"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-android-arm64@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-android-arm64@npm:11.5.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-darwin-arm64@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-darwin-arm64@npm:11.5.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-darwin-x64@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-darwin-x64@npm:11.5.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-freebsd-x64@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-freebsd-x64@npm:11.5.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.5.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm-musleabihf@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-linux-arm-musleabihf@npm:11.5.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm64-gnu@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-linux-arm64-gnu@npm:11.5.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm64-musl@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-linux-arm64-musl@npm:11.5.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-ppc64-gnu@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-linux-ppc64-gnu@npm:11.5.2"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-riscv64-gnu@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-linux-riscv64-gnu@npm:11.5.2"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-riscv64-musl@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-linux-riscv64-musl@npm:11.5.2"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-s390x-gnu@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-linux-s390x-gnu@npm:11.5.2"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-x64-gnu@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-linux-x64-gnu@npm:11.5.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-x64-musl@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-linux-x64-musl@npm:11.5.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-wasm32-wasi@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-wasm32-wasi@npm:11.5.2"
+  dependencies:
+    "@napi-rs/wasm-runtime": "npm:^0.2.11"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-win32-arm64-msvc@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-win32-arm64-msvc@npm:11.5.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-win32-ia32-msvc@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-win32-ia32-msvc@npm:11.5.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-win32-x64-msvc@npm:11.5.2":
+  version: 11.5.2
+  resolution: "@oxc-resolver/binding-win32-x64-msvc@npm:11.5.2"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3760,7 +3896,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.2, fast-glob@npm:^3.3.2":
+"fast-glob@npm:^3.2.2, fast-glob@npm:^3.3.2, fast-glob@npm:^3.3.3":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:
@@ -3800,6 +3936,15 @@ __metadata:
   dependencies:
     reusify: "npm:^1.0.4"
   checksum: 10c0/ebc6e50ac7048daaeb8e64522a1ea7a26e92b3cee5cd1c7f2316cdca81ba543aa40a136b53891446ea5c3a67ec215fbaca87ad405f102dd97012f62916905630
+  languageName: node
+  linkType: hard
+
+"fd-package-json@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fd-package-json@npm:2.0.0"
+  dependencies:
+    walk-up-path: "npm:^4.0.0"
+  checksum: 10c0/a0a48745257bc09c939486608dad9f2ced238f0c64266222cc881618ed4c8f6aa0ccfe45a1e6d4f9ce828509e8d617cec60e2a114851bebb1ff4886dc5ed5112
   languageName: node
   linkType: hard
 
@@ -3901,6 +4046,17 @@ __metadata:
     cross-spawn: "npm:^7.0.6"
     signal-exit: "npm:^4.0.1"
   checksum: 10c0/8986e4af2430896e65bc2788d6679067294d6aee9545daefc84923a0a4b399ad9c7a3ea7bd8c0b2b80fdf4a92de4c69df3f628233ff3224260e9c1541a9e9ed3
+  languageName: node
+  linkType: hard
+
+"formatly@npm:^0.2.4":
+  version: 0.2.4
+  resolution: "formatly@npm:0.2.4"
+  dependencies:
+    fd-package-json: "npm:^2.0.0"
+  bin:
+    formatly: bin/index.mjs
+  checksum: 10c0/43c6272a12199bc6319e7ef7043f209e7005fc35bc1b15e96ef16ad46a12fddc2b7c179fe8ade174c728e8454e3ebdc8428867cee78b082d18a91dae72866336
   languageName: node
   linkType: hard
 
@@ -4828,6 +4984,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jiti@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "jiti@npm:2.4.2"
+  bin:
+    jiti: lib/jiti-cli.mjs
+  checksum: 10c0/4ceac133a08c8faff7eac84aabb917e85e8257f5ad659e843004ce76e981c457c390a220881748ac67ba1b940b9b729b30fb85cbaf6e7989f04b6002c94da331
+  languageName: node
+  linkType: hard
+
 "jju@npm:~1.4.0":
   version: 1.4.0
   resolution: "jju@npm:1.4.0"
@@ -4943,6 +5108,33 @@ __metadata:
   dependencies:
     json-buffer: "npm:3.0.1"
   checksum: 10c0/aa52f3c5e18e16bb6324876bb8b59dd02acf782a4b789c7b2ae21107fab95fab3890ed448d4f8dba80ce05391eeac4bfabb4f02a20221342982f806fa2cf271e
+  languageName: node
+  linkType: hard
+
+"knip@npm:5.61.3":
+  version: 5.61.3
+  resolution: "knip@npm:5.61.3"
+  dependencies:
+    "@nodelib/fs.walk": "npm:^1.2.3"
+    fast-glob: "npm:^3.3.3"
+    formatly: "npm:^0.2.4"
+    jiti: "npm:^2.4.2"
+    js-yaml: "npm:^4.1.0"
+    minimist: "npm:^1.2.8"
+    oxc-resolver: "npm:^11.1.0"
+    picocolors: "npm:^1.1.1"
+    picomatch: "npm:^4.0.1"
+    smol-toml: "npm:^1.3.4"
+    strip-json-comments: "npm:5.0.2"
+    zod: "npm:^3.22.4"
+    zod-validation-error: "npm:^3.0.3"
+  peerDependencies:
+    "@types/node": ">=18"
+    typescript: ">=5.0.4"
+  bin:
+    knip: bin/knip.js
+    knip-bun: bin/knip-bun.js
+  checksum: 10c0/2f8abef32829e10f43a8374f254be871a792b9a7c8fdc4eda5630813f9d7cd310c9e0c68093a70b5ceeb3a6b20413705523ed75e482a6f5c80bb3323d2687dcf
   languageName: node
   linkType: hard
 
@@ -5140,7 +5332,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.6":
+"minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.6, minimist@npm:^1.2.8":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
@@ -5616,6 +5808,73 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oxc-resolver@npm:^11.1.0":
+  version: 11.5.2
+  resolution: "oxc-resolver@npm:11.5.2"
+  dependencies:
+    "@oxc-resolver/binding-android-arm-eabi": "npm:11.5.2"
+    "@oxc-resolver/binding-android-arm64": "npm:11.5.2"
+    "@oxc-resolver/binding-darwin-arm64": "npm:11.5.2"
+    "@oxc-resolver/binding-darwin-x64": "npm:11.5.2"
+    "@oxc-resolver/binding-freebsd-x64": "npm:11.5.2"
+    "@oxc-resolver/binding-linux-arm-gnueabihf": "npm:11.5.2"
+    "@oxc-resolver/binding-linux-arm-musleabihf": "npm:11.5.2"
+    "@oxc-resolver/binding-linux-arm64-gnu": "npm:11.5.2"
+    "@oxc-resolver/binding-linux-arm64-musl": "npm:11.5.2"
+    "@oxc-resolver/binding-linux-ppc64-gnu": "npm:11.5.2"
+    "@oxc-resolver/binding-linux-riscv64-gnu": "npm:11.5.2"
+    "@oxc-resolver/binding-linux-riscv64-musl": "npm:11.5.2"
+    "@oxc-resolver/binding-linux-s390x-gnu": "npm:11.5.2"
+    "@oxc-resolver/binding-linux-x64-gnu": "npm:11.5.2"
+    "@oxc-resolver/binding-linux-x64-musl": "npm:11.5.2"
+    "@oxc-resolver/binding-wasm32-wasi": "npm:11.5.2"
+    "@oxc-resolver/binding-win32-arm64-msvc": "npm:11.5.2"
+    "@oxc-resolver/binding-win32-ia32-msvc": "npm:11.5.2"
+    "@oxc-resolver/binding-win32-x64-msvc": "npm:11.5.2"
+    napi-postinstall: "npm:^0.3.0"
+  dependenciesMeta:
+    "@oxc-resolver/binding-android-arm-eabi":
+      optional: true
+    "@oxc-resolver/binding-android-arm64":
+      optional: true
+    "@oxc-resolver/binding-darwin-arm64":
+      optional: true
+    "@oxc-resolver/binding-darwin-x64":
+      optional: true
+    "@oxc-resolver/binding-freebsd-x64":
+      optional: true
+    "@oxc-resolver/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxc-resolver/binding-linux-arm-musleabihf":
+      optional: true
+    "@oxc-resolver/binding-linux-arm64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-arm64-musl":
+      optional: true
+    "@oxc-resolver/binding-linux-ppc64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-riscv64-musl":
+      optional: true
+    "@oxc-resolver/binding-linux-s390x-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-x64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-x64-musl":
+      optional: true
+    "@oxc-resolver/binding-wasm32-wasi":
+      optional: true
+    "@oxc-resolver/binding-win32-arm64-msvc":
+      optional: true
+    "@oxc-resolver/binding-win32-ia32-msvc":
+      optional: true
+    "@oxc-resolver/binding-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/236d0c732a83fcfa9e985f14236b1a21ee4287b9543b39cd1dc67fdd786e92e8cc95a2f83793ef59ca8785dffa871545c6d3b15bd1313a35d946f276bcd0430a
+  languageName: node
+  linkType: hard
+
 "p-cancelable@npm:^2.0.0":
   version: 2.1.1
   resolution: "p-cancelable@npm:2.1.1"
@@ -5797,7 +6056,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2":
+"picomatch@npm:^4.0.1, picomatch@npm:^4.0.2":
   version: 4.0.2
   resolution: "picomatch@npm:4.0.2"
   checksum: 10c0/7c51f3ad2bb42c776f49ebf964c644958158be30d0a510efd5a395e8d49cb5acfed5b82c0c5b365523ce18e6ab85013c9ebe574f60305892ec3fa8eee8304ccc
@@ -6494,6 +6753,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"smol-toml@npm:^1.3.4":
+  version: 1.4.1
+  resolution: "smol-toml@npm:1.4.1"
+  checksum: 10c0/0589866e6949a1d6db92e67af57b4c8a1b284e19e215cda2a0e88f43ab91677d077724fad39ff5e6a0912150c743f5f4e560da675d565348ee8c65417096b0af
+  languageName: node
+  linkType: hard
+
 "smtp-address-parser@npm:^1.0.3":
   version: 1.1.0
   resolution: "smtp-address-parser@npm:1.1.0"
@@ -6746,6 +7012,13 @@ __metadata:
   version: 3.0.0
   resolution: "strip-bom@npm:3.0.0"
   checksum: 10c0/51201f50e021ef16672593d7434ca239441b7b760e905d9f33df6e4f3954ff54ec0e0a06f100d028af0982d6f25c35cd5cda2ce34eaebccd0250b8befb90d8f1
+  languageName: node
+  linkType: hard
+
+"strip-json-comments@npm:5.0.2":
+  version: 5.0.2
+  resolution: "strip-json-comments@npm:5.0.2"
+  checksum: 10c0/e9841b8face78a01b0eb66f81e0a3419186a96f1d26817a5e1f5260b0631c10e0a7f711dddc5988edf599e5c079e4dd6e91defd21523e556636ba5679786f5ac
   languageName: node
   linkType: hard
 
@@ -7338,6 +7611,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"walk-up-path@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "walk-up-path@npm:4.0.0"
+  checksum: 10c0/fabe344f91387d1d41df230af962ef18bf703dd4178006d55cd6412caacd187b54440002d4d53a982d4f7f0455567dcffb6d3884533c8b2268928eca3ebd8a19
+  languageName: node
+  linkType: hard
+
 "which-boxed-primitive@npm:^1.1.0, which-boxed-primitive@npm:^1.1.1":
   version: 1.1.1
   resolution: "which-boxed-primitive@npm:1.1.1"
@@ -7589,5 +7869,21 @@ __metadata:
   dependencies:
     "@types/yoga-layout": "npm:1.9.2"
   checksum: 10c0/e83b6b7078faf4d0472461b53e92bf9cae655de3d896aee5f79b5ba5a960e507bbf8e671b261db13137bf18711686969f19fd1d9c4669beb1d70754b83c5879d
+  languageName: node
+  linkType: hard
+
+"zod-validation-error@npm:^3.0.3":
+  version: 3.5.3
+  resolution: "zod-validation-error@npm:3.5.3"
+  peerDependencies:
+    zod: ^3.25.0 || ^4.0.0
+  checksum: 10c0/4a1054f49049a5414857a4a85ae7b853d59be83dedb89942d4966345a58bd26d939beb574f0f5592fe4cc9963b26ac306d5b0950f6905651569059ef3517c803
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.22.4":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
   languageName: node
   linkType: hard


### PR DESCRIPTION
use `knip` to test for missing dependencies.
since the `import/no-extraneous-dependencies` eslint rule is not working.

- fixes #343

TODO / DONE
- [x] add tool
- [x] configure tool
- [x] add GH workflow