### PR TITLE
chore: use yarn4.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,5 +180,5 @@
     "dogfooding": "node $PROJECT_CWD/bin/cyclonedx-yarn-cli.js"
   },
   "preferUnplugged": true,
-  "packageManager": "yarn@4.15.0"
+  "packageManager": "yarn@4.16.0"
 }


### PR DESCRIPTION
was yarn 4.15.0 -- https://github.com/CycloneDX/cyclonedx-node-yarn/pull/552

blocked by https://github.com/yarnpkg/berry/issues/7211