### PR TITLE
build: revisit build pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,12 +220,12 @@ jobs:
     env:
       NPMJS_RELEASE_TAG: ${{ github.event.inputs.prerelease == 'true' && 'unstable-prerelease' || 'latest' }}
     steps:
-      - name: fetch build artifact
-        # see https://github.com/actions/download-artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Checkout
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          name: ${{ env.DIST_DIR }}
-          path: .
+          ref: ${{ needs.bump.outputs.version }}
+          persist-credentials: false
       - name: Setup Node.js ${{ env.NODE_ACTIVE_LTS }}
         # see https://github.com/actions/setup-node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -238,8 +238,14 @@ jobs:
           corepack enable yarn
           corepack prepare --activate yarn@4
           yarn -v
-      - name: yarn install
+      - name: Setup subject
         run: yarn install --immutable
+      - name: fetch build artifact
+        # see https://github.com/actions/download-artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.BUNDLES_DIR }}
+          path: ${{ env.BUNDLES_DIR }}
       - name: publish to registry as "${{ env.NPMJS_RELEASE_TAG }}"
         run: >
           yarn npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,8 +239,7 @@ jobs:
           corepack prepare --activate yarn@4
           yarn -v
       - name: Setup subject
-        run: |  # dist dir does not come with a lock file
-          yarn install --no-immutable
+        run: yarn install --immutable
       - name: publish to registry as "${{ env.NPMJS_RELEASE_TAG }}"
         run: >
           yarn npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,12 +220,12 @@ jobs:
     env:
       NPMJS_RELEASE_TAG: ${{ github.event.inputs.prerelease == 'true' && 'unstable-prerelease' || 'latest' }}
     steps:
-      - name: Checkout
-        # see https://github.com/actions/checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: fetch build artifact
+        # see https://github.com/actions/download-artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          ref: ${{ needs.bump.outputs.version }}
-          persist-credentials: false
+          name: ${{ env.DIST_DIR }}
+          path: .
       - name: Setup Node.js ${{ env.NODE_ACTIVE_LTS }}
         # see https://github.com/actions/setup-node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -239,13 +239,8 @@ jobs:
           corepack prepare --activate yarn@4
           yarn -v
       - name: Setup subject
-        run: yarn install --immutable
-      - name: fetch build artifact
-        # see https://github.com/actions/download-artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ env.BUNDLES_DIR }}
-          path: ${{ env.BUNDLES_DIR }}
+        run: |  # dist dir does not come with a lock file
+          yarn install --no-immutable
       - name: publish to registry as "${{ env.NPMJS_RELEASE_TAG }}"
         run: >
           yarn npm publish

--- a/tools/write-dist-manifest.cjs
+++ b/tools/write-dist-manifest.cjs
@@ -22,12 +22,13 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
  * @internal
  */
 
-const { readFileSync, writeFileSync } = require('node:fs')
-const { dirname, join } = require('node:path')
+const { cpSync, readFileSync, writeFileSync } = require('node:fs')
+const { dirname, basename,  join } = require('node:path')
 
 const projectRoot = join(__dirname, '..')
 
 const manifestSourceFile = join(projectRoot, 'package.json')
+const lockSourceFile = join(projectRoot, 'yarn.lock')
 
 const structuredClonePolyfill =
   typeof structuredClone === 'function'
@@ -62,8 +63,8 @@ function main (outputFile) {
 
   writeFileSync(outputFile, JSON.stringify(manifest, undefined, 2))
 
-  // also write an empty yarn.lock
-  writeFileSync(join(dirname(outputFile), 'yarn.lock'), '')
+  // also copy the original yarn.lock
+  cpSync(lockSourceFile, join(dirname(outputFile), basename(lockSourceFile)))
 }
 
 if (require.main === module) {

--- a/tools/write-dist-manifest.cjs
+++ b/tools/write-dist-manifest.cjs
@@ -55,7 +55,7 @@ function main (outputFile) {
   manifest.publishReplace = undefined
   // dist is expected to be a bundle - no deps need install
   manifest.dependencies = {}
-  // move deps to devDeps - for documentation purposes
+  // move deps to devDeps - for documentation purposes and release pipeline
   manifest.devDependencies = {
     ...manifestSource.dependencies,
     ...manifestSource.devDependencies,

--- a/tools/write-dist-manifest.cjs
+++ b/tools/write-dist-manifest.cjs
@@ -23,7 +23,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 
 const { cpSync, readFileSync, writeFileSync } = require('node:fs')
-const { dirname, basename,  join } = require('node:path')
+const { basename, dirname, join } = require('node:path')
 
 const projectRoot = join(__dirname, '..')
 


### PR DESCRIPTION
copy the original lock file, so we dont install unexpected versions 