### PR TITLE
fix: prune devDependencies of virtualized workspaces under --prod (#256)

### DIFF
--- a/src/builders.ts
+++ b/src/builders.ts
@@ -128,8 +128,15 @@ export class BomBuilder {
 
     const rootPackage = workspace.anchoredPackage
     if (this.omitDevDependencies) {
-      for (const dep of workspace.manifest.devDependencies.keys()) {
-        rootPackage.dependencies.delete(dep)
+      for (const pkg of workspace.project.storedPackages.values()) {
+        const locator = structUtils.isVirtualLocator(pkg)
+          ? structUtils.devirtualizeLocator(pkg)
+          : pkg
+        const ws = workspace.project.tryWorkspaceByLocator(locator)
+        if (ws === null) { continue }
+        for (const devDep of ws.manifest.devDependencies.keys()) {
+          pkg.dependencies.delete(devDep)
+        }
       }
     }
     for await (const component of this.gatherDependencies(

--- a/tests/_data/snapshots/prod-arg_local-workspaces.json.bin
+++ b/tests/_data/snapshots/prod-arg_local-workspaces.json.bin
@@ -295,74 +295,6 @@
     },
     {
       "type": "library",
-      "name": "is-number",
-      "version": "7.0.0",
-      "bom-ref": "is-number@npm:7.0.0",
-      "author": "Jon Schlinkert",
-      "description": "Returns true if a number or string value is a finite number. Useful for regex matches, parsing, user input, etc.",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/is-number@7.0.0",
-      "externalReferences": [
-        {
-          "url": "https://github.com/jonschlinkert/is-number/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \"bugs.url\""
-        },
-        {
-          "url": "git+https://github.com/jonschlinkert/is-number.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \"repository.url\""
-        },
-        {
-          "url": "https://github.com/jonschlinkert/is-number",
-          "type": "website",
-          "comment": "as detected from PackageJson property \"homepage\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "is-stream",
-      "version": "4.0.1",
-      "bom-ref": "is-stream@npm:4.0.1",
-      "author": "Sindre Sorhus",
-      "description": "Check if something is a Node.js stream",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/is-stream@4.0.1",
-      "externalReferences": [
-        {
-          "url": "https://github.com/sindresorhus/is-stream/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \"bugs.url\""
-        },
-        {
-          "url": "git+https://github.com/sindresorhus/is-stream.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \"repository.url\""
-        },
-        {
-          "url": "https://github.com/sindresorhus/is-stream#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \"homepage\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "my-local-a",
       "version": "0.1.0",
       "bom-ref": "my-local-a@workspace:workspaces/my-local-a",
@@ -473,12 +405,6 @@
       "ref": "is-hexadecimal@npm:2.0.1"
     },
     {
-      "ref": "is-number@npm:7.0.0"
-    },
-    {
-      "ref": "is-stream@npm:4.0.1"
-    },
-    {
       "ref": "my-local-a@workspace:workspaces/my-local-a",
       "dependsOn": [
         "my-local-b-off@workspace:workspaces/my-local-b"
@@ -488,12 +414,7 @@
       "ref": "my-local-b-off@workspace:workspaces/my-local-b"
     },
     {
-      "ref": "with-dev-deps@workspace:workspaces/with-dev-deps",
-      "dependsOn": [
-        "is-decimal@npm:2.0.1",
-        "is-number@npm:7.0.0",
-        "is-stream@npm:4.0.1"
-      ]
+      "ref": "with-dev-deps@workspace:workspaces/with-dev-deps"
     },
     {
       "ref": "with-peer-deps@workspace:workspaces/with-peer-deps [be205]",

--- a/tests/_data/snapshots/prod-arg_local-workspaces.xml.bin
+++ b/tests/_data/snapshots/prod-arg_local-workspaces.xml.bin
@@ -223,58 +223,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="is-number@npm:7.0.0">
-      <author>Jon Schlinkert</author>
-      <name>is-number</name>
-      <version>7.0.0</version>
-      <description>Returns true if a number or string value is a finite number. Useful for regex matches, parsing, user input, etc.</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/is-number@7.0.0</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/jonschlinkert/is-number/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/jonschlinkert/is-number.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/jonschlinkert/is-number</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="is-stream@npm:4.0.1">
-      <author>Sindre Sorhus</author>
-      <name>is-stream</name>
-      <version>4.0.1</version>
-      <description>Check if something is a Node.js stream</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/is-stream@4.0.1</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/sindresorhus/is-stream/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/sindresorhus/is-stream.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/sindresorhus/is-stream#readme</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="my-local-a@workspace:workspaces/my-local-a">
       <name>my-local-a</name>
       <version>0.1.0</version>
@@ -350,17 +298,11 @@
     </dependency>
     <dependency ref="is-decimal@npm:2.0.1"/>
     <dependency ref="is-hexadecimal@npm:2.0.1"/>
-    <dependency ref="is-number@npm:7.0.0"/>
-    <dependency ref="is-stream@npm:4.0.1"/>
     <dependency ref="my-local-a@workspace:workspaces/my-local-a">
       <dependency ref="my-local-b-off@workspace:workspaces/my-local-b"/>
     </dependency>
     <dependency ref="my-local-b-off@workspace:workspaces/my-local-b"/>
-    <dependency ref="with-dev-deps@workspace:workspaces/with-dev-deps">
-      <dependency ref="is-decimal@npm:2.0.1"/>
-      <dependency ref="is-number@npm:7.0.0"/>
-      <dependency ref="is-stream@npm:4.0.1"/>
-    </dependency>
+    <dependency ref="with-dev-deps@workspace:workspaces/with-dev-deps"/>
     <dependency ref="with-peer-deps@workspace:workspaces/with-peer-deps [be205]">
       <dependency ref="is-bigint@npm:1.1.0"/>
     </dependency>


### PR DESCRIPTION
### Description

Under `--prod`, `devDependencies` of workspaces leak into the SBOM when the workspace is virtualized.

A workspace on the resolution path of a peer dependency is resolved by Yarn as *virtual* packages, each with its own `locatorHash` and copy of the `dependencies` map — this happens even when no workspace manifest declares `peerDependencies`, since a transitive npm dependency declaring a peer is enough. The SBOM traversal walks those virtual instances, but the previous `--prod` prune only mutated the scanned workspace's `anchoredPackage`, so dev edges on the virtual copies survived and their targets were emitted as production components.

This PR prunes across `project.storedPackages`, devirtualizing each locator (`structUtils.devirtualizeLocator` + `tryWorkspaceByLocator`) so dev edges are removed from every workspace instance including virtual copies. Edges are removed rather than components filtered by identity, so a package that is a `devDependency` of one workspace but a genuine transitive prod dependency elsewhere is correctly retained.

This also covers the case #456 misses: that PR filters by ident on anchored workspace packages, which never match virtual instances (different `locatorHash`, `virtual:`-prefixed reference).

Adds a regression testbed (`workspace-peer-dev-dependencies`) where a child workspace is virtualized via a transitive peer (`use-sync-external-store` → `react`) with no workspace-level `peerDependencies`, carrying a dev-only `is-number`; snapshots assert `is-number` is absent under `--prod` and present without it. Also verified against a real-world Yarn Berry monorepo.

Resolves or fixes issue: #256

### AI Tool Disclosure
- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `Claude (claude.ai)`
  - LLMs and versions: `Claude Opus 4.8`
  - Prompts: e.g `Diagnosing why --prod includes transitive workspace devDependencies`, `Generate test-suite for this case`, and `fill in this PR description form`

### Affirmation
- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-node-yarn/blob/main/CONTRIBUTING.md) guidelines