### PR TITLE
feat: add runtime engine constraints to metadata component

### DIFF
--- a/src/builders.ts
+++ b/src/builders.ts
@@ -41,11 +41,26 @@ import {
   trySanitizeGitUrl
 } from './_helpers'
 import type { PackageUrlFactory } from './factories'
-import { PropertyNames, PropertyValueBool } from './properties'
+import { PropertyNamePrefixes, PropertyNames, PropertyValueBool } from './properties'
 
 
 type ManifestFetcher = (pkg: Package) => Promise<NonNullable<any>>
 type LicenseEvidenceFetcher = (pkg: Package) => AsyncGenerator<License>
+
+function addEngineConstraintProperties (component: Component, engines: unknown): void {
+  if (engines === null || typeof engines !== 'object' || Array.isArray(engines)) {
+    return
+  }
+
+  for (const [name, constraint] of Object.entries(engines)) {
+    if (isString(constraint)) {
+      component.properties.add(new Property(
+        `${PropertyNamePrefixes.PackageEngineConstraint}${name}`,
+        constraint
+      ))
+    }
+  }
+}
 
 interface BomBuilderOptions {
   omitDevDependencies?: BomBuilder['omitDevDependencies']
@@ -102,6 +117,7 @@ export class BomBuilder {
     const rootComponent: Component = this.makeComponentFromWorkspace(workspace, this.metaComponentType)
       ?? new DummyComponent(this.metaComponentType, 'RootComponent')
     rootComponent.licenses.forEach(setLicensesDeclared)
+    addEngineConstraintProperties(rootComponent, workspace.manifest.raw.engines)
 
     const bom = new Bom()
 

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -33,6 +33,10 @@ export const enum PropertyNames {
   PackageDevelopment = 'cdx:npm:package:development',
 }
 
+export const enum PropertyNamePrefixes {
+  PackageEngineConstraint = 'cdx:npm:package:constraint:engine:',
+}
+
 /**
  * CDX properties' values' boolean representation - specific to this very tool.
  * @see {@link https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/npm.md | npm property taxonomy}

--- a/tests/_data/snapshots/license-evidence-dev_juice-shop.json.bin
+++ b/tests/_data/snapshots/license-evidence-dev_juice-shop.json.bin
@@ -97,6 +97,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:constraint:engine:node",
+          "value": "18 - 21"
+        }
       ]
     },
     "properties": [

--- a/tests/_data/snapshots/license-evidence-dev_juice-shop.xml.bin
+++ b/tests/_data/snapshots/license-evidence-dev_juice-shop.xml.bin
@@ -76,6 +76,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:constraint:engine:node">18 - 21</property>
+      </properties>
     </component>
     <properties>
       <property name="cdx:reproducible">true</property>

--- a/tests/_data/snapshots/license-evidence-prod_juice-shop.json.bin
+++ b/tests/_data/snapshots/license-evidence-prod_juice-shop.json.bin
@@ -97,6 +97,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:constraint:engine:node",
+          "value": "18 - 21"
+        }
       ]
     },
     "properties": [

--- a/tests/_data/snapshots/license-evidence-prod_juice-shop.xml.bin
+++ b/tests/_data/snapshots/license-evidence-prod_juice-shop.xml.bin
@@ -76,6 +76,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:constraint:engine:node">18 - 21</property>
+      </properties>
     </component>
     <properties>
       <property name="cdx:reproducible">true</property>

--- a/tests/_data/snapshots/plain_package-aliasing.json.bin
+++ b/tests/_data/snapshots/plain_package-aliasing.json.bin
@@ -88,6 +88,16 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:constraint:engine:node",
+          "value": ">=18"
+        },
+        {
+          "name": "cdx:npm:package:constraint:engine:yarn",
+          "value": ">=4"
+        }
       ]
     },
     "properties": [

--- a/tests/_data/snapshots/plain_package-aliasing.xml.bin
+++ b/tests/_data/snapshots/plain_package-aliasing.xml.bin
@@ -70,6 +70,10 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:constraint:engine:node">&gt;=18</property>
+        <property name="cdx:npm:package:constraint:engine:yarn">&gt;=4</property>
+      </properties>
     </component>
     <properties>
       <property name="cdx:reproducible">true</property>


### PR DESCRIPTION
### Description

Map string values from the root workspace's `package.json` `engines` object to `metadata.component.properties` using the CycloneDX npm property taxonomy:

`cdx:npm:package:constraint:engine:<name> = <version range>`

This preserves arbitrary runtime names, ignores malformed or non-string values, and leaves SBOM output unchanged when `engines` is absent. JSON and XML snapshots cover both a multi-runtime manifest and an existing Node-only manifest.

Resolves or fixes issue: #448

### Validation

- `yarn test:node` on Node.js 24: 61 passing
- `yarn test:standard`
- `yarn test:lint`
- `yarn test:dependencies`

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `OpenAI Codex`
  - LLMs and versions: `GPT-5`
  - Prompts: `Inspect the issue and contribution requirements; implement the engines-to-CycloneDX property mapping; update fixture snapshots; run focused and full tests; review the final diff.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-node-yarn/blob/main/CONTRIBUTING.md) guidelines
